### PR TITLE
hotfix What's New page not working in presence of private sources

### DIFF
--- a/MPCAutofill/cardpicker/documents.py
+++ b/MPCAutofill/cardpicker/documents.py
@@ -38,7 +38,7 @@ class CardSearch(Document):
             "priority": self.priority,
             "source": self.source,
             "source_name": self.source_name,
-            "source_external_link": self.source_external_link,
+            "source_external_link": self.source_external_link or "",
             "source_verbose": self.source_verbose,
             "source_type": self.source_type,
             "dpi": self.dpi,


### PR DESCRIPTION
# Description

I noticed on the deployed site that the What's New page was hitting a javascript error - apologies for this, I hadn't tested this page with a private google drive :/

# Checklist

- [x] I have installed `pre-commit` and run the hooks with `pre-commit run`.
- [x] I have updated any related tests for code I modified or added new tests where appropriate.
- [x] I have updated any relevant documentation or created new documentation where appropriate.